### PR TITLE
Support of CASE operator in SELECT query

### DIFF
--- a/case.go
+++ b/case.go
@@ -100,8 +100,8 @@ func (b CaseBuilder) ToSql() (string, []interface{}, error) {
 	return data.ToSql()
 }
 
-// What sets optional value for CASE construct "CASE [value] ..."
-func (b CaseBuilder) What(expr interface{}) CaseBuilder {
+// what sets optional value for CASE construct "CASE [value] ..."
+func (b CaseBuilder) what(expr interface{}) CaseBuilder {
 	return builder.Set(b, "What", newPart(expr)).(CaseBuilder)
 }
 

--- a/case.go
+++ b/case.go
@@ -1,0 +1,112 @@
+package squirrel
+
+import (
+	"bytes"
+
+	"github.com/lann/builder"
+)
+
+func init() {
+	builder.Register(CaseBuilder{}, caseData{})
+}
+
+// sqlizerBuffer is a helper that allows to write many Sqlizers one by one
+// without constant checks for errors that may come from Sqlizer
+type sqlizerBuffer struct {
+	bytes.Buffer
+	args []interface{}
+	err  error
+}
+
+// WriteSql converts Sqlizer to SQL strings and writes it to buffer
+func (b *sqlizerBuffer) WriteSql(item Sqlizer) {
+	if b.err != nil {
+		return
+	}
+
+	var str string
+	var args []interface{}
+	str, args, b.err = item.ToSql()
+
+	if b.err != nil {
+		return
+	}
+
+	b.WriteString(str)
+	b.WriteByte(' ')
+	b.args = append(b.args, args...)
+}
+
+func (b *sqlizerBuffer) ToSql() (string, []interface{}, error) {
+	return b.String(), b.args, b.err
+}
+
+// whenPart is a helper structure to describe SQLs "WHEN ... THEN ..." expression
+type whenPart struct {
+	when Sqlizer
+	then Sqlizer
+}
+
+func newWhenPart(when interface{}, then interface{}) whenPart {
+	return whenPart{newPart(when), newPart(then)}
+}
+
+// caseData holds all the data required to build a CASE SQL construct
+type caseData struct {
+	PlaceholderFormat PlaceholderFormat
+	What              Sqlizer
+	WhenParts         []whenPart
+	Else              Sqlizer
+}
+
+// ToSql implements Sqlizer
+func (d *caseData) ToSql() (string, []interface{}, error) {
+	sql := sqlizerBuffer{}
+
+	sql.WriteString("CASE ")
+	if d.What != nil {
+		sql.WriteSql(d.What)
+	}
+
+	for _, p := range d.WhenParts {
+		sql.WriteString("WHEN ")
+		sql.WriteSql(p.when)
+		sql.WriteString("THEN ")
+		sql.WriteSql(p.then)
+	}
+
+	if d.Else != nil {
+		sql.WriteString("ELSE ")
+		sql.WriteSql(d.Else)
+	}
+
+	sql.WriteString("END")
+
+	return sql.ToSql()
+}
+
+// CaseBuilder builds SQL CASE construct which could be used as parts of queries.
+type CaseBuilder builder.Builder
+
+// ToSql builds the query into a SQL string and bound args.
+func (b CaseBuilder) ToSql() (string, []interface{}, error) {
+	data := builder.GetStruct(b).(caseData)
+	return data.ToSql()
+}
+
+// What sets optional value for CASE construct "CASE [value] ..."
+func (b CaseBuilder) What(expr interface{}) CaseBuilder {
+	return builder.Set(b, "What", newPart(expr)).(CaseBuilder)
+}
+
+// When adds "WHEN ... THEN ..." part to CASE construct
+func (b CaseBuilder) When(when interface{}, then interface{}) CaseBuilder {
+	// TODO: performance hint: replace slice of WhenPart with just slice of parts
+	// where even indices of the slice belong to "when"s and odd indices belong to "then"s
+	return builder.Append(b, "WhenParts", newWhenPart(when, then)).(CaseBuilder)
+}
+
+// What sets optional "ELSE ..." part for CASE construct
+func (b CaseBuilder) Else(expr interface{}) CaseBuilder {
+	return builder.Set(b, "Else", newPart(expr)).(CaseBuilder)
+}

--- a/case.go
+++ b/case.go
@@ -2,6 +2,7 @@ package squirrel
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/lann/builder"
 )
@@ -59,7 +60,13 @@ type caseData struct {
 }
 
 // ToSql implements Sqlizer
-func (d *caseData) ToSql() (string, []interface{}, error) {
+func (d *caseData) ToSql() (sqlStr string, args []interface{}, err error) {
+	if len(d.WhenParts) == 0 {
+		err = errors.New("case expression must contain at lease one WHEN clause")
+
+		return
+	}
+
 	sql := sqlizerBuffer{}
 
 	sql.WriteString("CASE ")

--- a/case.go
+++ b/case.go
@@ -53,10 +53,9 @@ func newWhenPart(when interface{}, then interface{}) whenPart {
 
 // caseData holds all the data required to build a CASE SQL construct
 type caseData struct {
-	PlaceholderFormat PlaceholderFormat
-	What              Sqlizer
-	WhenParts         []whenPart
-	Else              Sqlizer
+	What      Sqlizer
+	WhenParts []whenPart
+	Else      Sqlizer
 }
 
 // ToSql implements Sqlizer

--- a/case_test.go
+++ b/case_test.go
@@ -1,0 +1,78 @@
+package squirrel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCaseWithVal(t *testing.T) {
+	caseStmt := Case().
+		What("number").
+		When("1", "one").
+		When("2", "two").
+		Else(Expr("?", "big number"))
+
+	qb := Select().
+		Column(caseStmt).
+		From("table")
+	sql, args, err := qb.ToSql()
+
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT CASE number " +
+		"WHEN 1 THEN one " +
+		"WHEN 2 THEN two " +
+		"ELSE ? " +
+		"END " +
+		"FROM table"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{"big number"}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestCaseWithNoVal(t *testing.T) {
+	caseStmt := Case().
+		When(Eq{"x": 0}, "x is zero").
+		When(Expr("x > ?", 1), Expr("CONCAT('x is greater than ', ?)", 2))
+
+	qb := Select().Column(caseStmt).From("table")
+	sql, args, err := qb.ToSql()
+
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT CASE " +
+		"WHEN x = ? THEN x is zero " +
+		"WHEN x > ? THEN CONCAT('x is greater than ', ?) " +
+		"END " +
+		"FROM table"
+
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{0, 1, 2}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestCaseWithExpr(t *testing.T) {
+	caseStmt := Case().
+		What(Expr("x = ?", true)).
+		When("true", Expr("?", "it's true!")).
+		Else("42")
+
+	qb := Select().Column(caseStmt).From("table")
+	sql, args, err := qb.ToSql()
+
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT CASE x = ? " +
+		"WHEN true THEN ? " +
+		"ELSE 42 " +
+		"END " +
+		"FROM table"
+
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{true, "it's true!"}
+	assert.Equal(t, expectedArgs, args)
+}

--- a/case_test.go
+++ b/case_test.go
@@ -76,3 +76,35 @@ func TestCaseWithExpr(t *testing.T) {
 	expectedArgs := []interface{}{true, "it's true!"}
 	assert.Equal(t, expectedArgs, args)
 }
+
+func TestMultipleCase(t *testing.T) {
+	caseStmtNoval := Case().
+		What(Expr("x = ?", true)).
+		When("true", Expr("?", "it's true!")).
+		Else("42")
+	caseStmtExpr := Case().
+		When(Eq{"x": 0}, "'x is zero'").
+		When(Expr("x > ?", 1), Expr("CONCAT('x is greater than ', ?)", 2))
+
+	qb := Select().
+		Column(Alias(caseStmtNoval, "case_noval")).
+		Column(Alias(caseStmtExpr, "case_expr")).
+		From("table")
+
+	sql, args, err := qb.ToSql()
+
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT " +
+		"CASE x = ? WHEN true THEN ? ELSE 42 END AS case_noval, " +
+		"CASE WHEN x = ? THEN 'x is zero' WHEN x > ? THEN CONCAT('x is greater than ', ?) END AS case_expr " +
+		"FROM table"
+
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{
+		true, "it's true!",
+		0, 1, 2,
+	}
+	assert.Equal(t, expectedArgs, args)
+}

--- a/case_test.go
+++ b/case_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func TestCaseWithVal(t *testing.T) {
-	caseStmt := Case().
-		What("number").
+	caseStmt := Case("number").
 		When("1", "one").
 		When("2", "two").
 		Else(Expr("?", "big number"))
@@ -55,8 +54,7 @@ func TestCaseWithNoVal(t *testing.T) {
 }
 
 func TestCaseWithExpr(t *testing.T) {
-	caseStmt := Case().
-		What(Expr("x = ?", true)).
+	caseStmt := Case(Expr("x = ?", true)).
 		When("true", Expr("?", "it's true!")).
 		Else("42")
 
@@ -78,8 +76,7 @@ func TestCaseWithExpr(t *testing.T) {
 }
 
 func TestMultipleCase(t *testing.T) {
-	caseStmtNoval := Case().
-		What(Expr("x = ?", true)).
+	caseStmtNoval := Case(Expr("x = ?", true)).
 		When("true", Expr("?", "it's true!")).
 		Else("42")
 	caseStmtExpr := Case().
@@ -110,8 +107,7 @@ func TestMultipleCase(t *testing.T) {
 }
 
 func TestCaseWithNoWhenClause(t *testing.T) {
-	caseStmt := Case().
-		What(Expr("x = ?", true)).
+	caseStmt := Case("something").
 		Else("42")
 
 	qb := Select().Column(caseStmt).From("table")

--- a/case_test.go
+++ b/case_test.go
@@ -96,8 +96,8 @@ func TestMultipleCase(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedSql := "SELECT " +
-		"CASE x = ? WHEN true THEN ? ELSE 42 END AS case_noval, " +
-		"CASE WHEN x = ? THEN 'x is zero' WHEN x > ? THEN CONCAT('x is greater than ', ?) END AS case_expr " +
+		"(CASE x = ? WHEN true THEN ? ELSE 42 END) AS case_noval, " +
+		"(CASE WHEN x = ? THEN 'x is zero' WHEN x > ? THEN CONCAT('x is greater than ', ?) END) AS case_expr " +
 		"FROM table"
 
 	assert.Equal(t, expectedSql, sql)

--- a/case_test.go
+++ b/case_test.go
@@ -108,3 +108,17 @@ func TestMultipleCase(t *testing.T) {
 	}
 	assert.Equal(t, expectedArgs, args)
 }
+
+func TestCaseWithNoWhenClause(t *testing.T) {
+	caseStmt := Case().
+		What(Expr("x = ?", true)).
+		Else("42")
+
+	qb := Select().Column(caseStmt).From("table")
+
+	_, _, err := qb.ToSql()
+
+	assert.Error(t, err)
+
+	assert.Equal(t, "case expression must contain at lease one WHEN clause", err.Error())
+}

--- a/case_test.go
+++ b/case_test.go
@@ -31,6 +31,27 @@ func TestCaseWithVal(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
+func TestCaseWithComplexVal(t *testing.T) {
+	caseStmt := Case("? > ?", 10, 5).
+		When("true", "'T'")
+
+	qb := Select().
+		Column(Alias(caseStmt, "complexCase")).
+		From("table")
+	sql, args, err := qb.ToSql()
+
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT (CASE ? > ? " +
+		"WHEN true THEN 'T' " +
+		"END) AS complexCase " +
+		"FROM table"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{10, 5}
+	assert.Equal(t, expectedArgs, args)
+}
+
 func TestCaseWithNoVal(t *testing.T) {
 	caseStmt := Case().
 		When(Eq{"x": 0}, "x is zero").

--- a/expr.go
+++ b/expr.go
@@ -43,6 +43,28 @@ func (es exprs) AppendToSql(w io.Writer, sep string, args []interface{}) ([]inte
 	return args, nil
 }
 
+// aliasExpr helps to alias part of SQL query generated with underlying "expr"
+type aliasExpr struct {
+	expr  Sqlizer
+	alias string
+}
+
+// Alias allows to define alias for column in SelectBuilder. Useful when column is
+// defined as complex expression like IF or CASE
+// Ex:
+//		.Column(Alias(caseStmt, "case_column"))
+func Alias(expr Sqlizer, alias string) aliasExpr {
+	return aliasExpr{expr, alias}
+}
+
+func (e aliasExpr) ToSql() (sql string, args []interface{}, err error) {
+	sql, args, err = e.expr.ToSql()
+	if err == nil {
+		sql = fmt.Sprintf("%s AS %s", sql, e.alias)
+	}
+	return
+}
+
 // Eq is syntactic sugar for use with Where/Having/Set methods.
 // Ex:
 //     .Where(Eq{"id": 1})

--- a/expr.go
+++ b/expr.go
@@ -60,7 +60,7 @@ func Alias(expr Sqlizer, alias string) aliasExpr {
 func (e aliasExpr) ToSql() (sql string, args []interface{}, err error) {
 	sql, args, err = e.expr.ToSql()
 	if err == nil {
-		sql = fmt.Sprintf("%s AS %s", sql, e.alias)
+		sql = fmt.Sprintf("(%s) AS %s", sql, e.alias)
 	}
 	return
 }

--- a/select_test.go
+++ b/select_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestSelectBuilderToSql(t *testing.T) {
+	subQ := Select("aa", "bb").From("dd")
 	b := Select("a", "b").
 		Prefix("WITH prefix AS ?", 0).
 		Distinct().
@@ -14,6 +15,7 @@ func TestSelectBuilderToSql(t *testing.T) {
 		Column("IF(d IN ("+Placeholders(3)+"), 1, 0) as stat_column", 1, 2, 3).
 		Column(Expr("a > ?", 100)).
 		Column(Alias(Eq{"b": []int{101, 102, 103}}, "b_alias")).
+		Column(Alias(subQ, "subq")).
 		From("e").
 		JoinClause("CROSS JOIN j1").
 		Join("j2").
@@ -36,7 +38,9 @@ func TestSelectBuilderToSql(t *testing.T) {
 
 	expectedSql :=
 		"WITH prefix AS ? " +
-			"SELECT DISTINCT a, b, c, IF(d IN (?,?,?), 1, 0) as stat_column, a > ?, b IN (?,?,?) AS b_alias " +
+			"SELECT DISTINCT a, b, c, IF(d IN (?,?,?), 1, 0) as stat_column, a > ?, " +
+			"(b IN (?,?,?)) AS b_alias, " +
+			"(SELECT aa, bb FROM dd) AS subq " +
 			"FROM e " +
 			"CROSS JOIN j1 JOIN j2 LEFT JOIN j3 RIGHT JOIN j4 " +
 			"WHERE f = ? AND g = ? AND h = ? AND i IN (?,?,?) AND (j = ? OR (k = ? AND true)) " +

--- a/select_test.go
+++ b/select_test.go
@@ -13,7 +13,7 @@ func TestSelectBuilderToSql(t *testing.T) {
 		Columns("c").
 		Column("IF(d IN ("+Placeholders(3)+"), 1, 0) as stat_column", 1, 2, 3).
 		Column(Expr("a > ?", 100)).
-		Column(Eq{"b": []int{101, 102, 103}}).
+		Column(Alias(Eq{"b": []int{101, 102, 103}}, "b_alias")).
 		From("e").
 		JoinClause("CROSS JOIN j1").
 		Join("j2").
@@ -36,7 +36,7 @@ func TestSelectBuilderToSql(t *testing.T) {
 
 	expectedSql :=
 		"WITH prefix AS ? " +
-			"SELECT DISTINCT a, b, c, IF(d IN (?,?,?), 1, 0) as stat_column, a > ?, b IN (?,?,?) " +
+			"SELECT DISTINCT a, b, c, IF(d IN (?,?,?), 1, 0) as stat_column, a > ?, b IN (?,?,?) AS b_alias " +
 			"FROM e " +
 			"CROSS JOIN j1 JOIN j2 LEFT JOIN j3 RIGHT JOIN j4 " +
 			"WHERE f = ? AND g = ? AND h = ? AND i IN (?,?,?) AND (j = ? OR (k = ? AND true)) " +

--- a/statement.go
+++ b/statement.go
@@ -67,13 +67,17 @@ func Delete(from string) DeleteBuilder {
 }
 
 // Case returns a new CaseBuilder
-// "what" represents case value, can be empty or just single value,
-// extra values are ignored
+// "what" represents case value
 func Case(what ...interface{}) CaseBuilder {
 	b := CaseBuilder(builder.EmptyBuilder)
-	if len(what) > 0 {
-		b = b.what(what[0])
-	}
 
+	switch len(what) {
+	case 0:
+	case 1:
+		b = b.what(what[0])
+	default:
+		b = b.what(newPart(what[0], what[1:]...))
+
+	}
 	return b
 }

--- a/statement.go
+++ b/statement.go
@@ -67,6 +67,13 @@ func Delete(from string) DeleteBuilder {
 }
 
 // Case returns a new CaseBuilder
-func Case() CaseBuilder {
-	return CaseBuilder(builder.EmptyBuilder)
+// "what" represents case value, can be empty or just single value,
+// extra values are ignored
+func Case(what ...interface{}) CaseBuilder {
+	b := CaseBuilder(builder.EmptyBuilder)
+	if len(what) > 0 {
+		b = b.what(what[0])
+	}
+
+	return b
 }

--- a/statement.go
+++ b/statement.go
@@ -25,6 +25,11 @@ func (b StatementBuilderType) Delete(from string) DeleteBuilder {
 	return DeleteBuilder(b).From(from)
 }
 
+// Case returns a CaseBuilder for this StatementBuilderType.
+func (b StatementBuilderType) Case() CaseBuilder {
+	return CaseBuilder(b)
+}
+
 // PlaceholderFormat sets the PlaceholderFormat field for any child builders.
 func (b StatementBuilderType) PlaceholderFormat(f PlaceholderFormat) StatementBuilderType {
 	return builder.Set(b, "PlaceholderFormat", f).(StatementBuilderType)
@@ -64,4 +69,9 @@ func Update(table string) UpdateBuilder {
 // See DeleteBuilder.Table.
 func Delete(from string) DeleteBuilder {
 	return StatementBuilder.Delete(from)
+}
+
+// Case returns a new CaseBuilder
+func Case() CaseBuilder {
+	return StatementBuilder.Case()
 }

--- a/statement.go
+++ b/statement.go
@@ -25,11 +25,6 @@ func (b StatementBuilderType) Delete(from string) DeleteBuilder {
 	return DeleteBuilder(b).From(from)
 }
 
-// Case returns a CaseBuilder for this StatementBuilderType.
-func (b StatementBuilderType) Case() CaseBuilder {
-	return CaseBuilder(b)
-}
-
 // PlaceholderFormat sets the PlaceholderFormat field for any child builders.
 func (b StatementBuilderType) PlaceholderFormat(f PlaceholderFormat) StatementBuilderType {
 	return builder.Set(b, "PlaceholderFormat", f).(StatementBuilderType)
@@ -73,5 +68,5 @@ func Delete(from string) DeleteBuilder {
 
 // Case returns a new CaseBuilder
 func Case() CaseBuilder {
-	return StatementBuilder.Case()
+	return CaseBuilder(builder.EmptyBuilder)
 }


### PR DESCRIPTION
Hi there! :)
Here's a proposal for support of `SELECT CASE` statements (http://dev.mysql.com/doc/refman/5.0/en/control-flow-functions.html#operator_case).
The commit contains test which shows an idea which is better to discuss before writing any real code. The interface is a matter of discussion.
Rationale of this proposal:
In current version of `squirrel` we have to pregenerate a subquery with `SELECT CASE`, like this, for example:
```
	var values map[string]string = loadValues()
	args = make([]interface{}, len(values)*2)

	buf.WriteString("(SELECT CASE")
	for k, v := range values {
		buf.WriteString(" WHEN value = ? THEN ?")
		args[i*2], args[i*2+1] = value, i
	}
	buf.WriteString(" END AS col1)")

	qb := squirrel.Select(buf.String()).From("sometable")
```

But in this case nothing stops developer from making mistakes like forgotten escaped value. Also we can use `squirrel` to pregenerate a separate subquery, but the code is still messy. Support of `SELECT CASE` can be used to protect the developer :)

```
	var values map[string]string = loadValues()
	qb := squirrel.Select("").
		From("sometable").
		Case(nil)

	for k, v := range values {
		qb = qb.WhenThen(squirrel.Eq{"value": value}, i)
	}

	qb = qb.EndCase("col1")
```
What do you think about this?

Regards,
Ivan.