### PR TITLE
Small optimization for placeholder generator.

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -73,13 +73,10 @@ func (eq Eq) toSql(useNotOpr bool) (sql string, args []interface{}, err error) {
 					err = fmt.Errorf("equality condition must contain at least one paramater")
 					return
 				}
-				placeholders := make([]string, valVal.Len())
 				for i := 0; i < valVal.Len(); i++ {
-					placeholders[i] = "?"
 					args = append(args, valVal.Index(i).Interface())
 				}
-				placeholdersStr := strings.Join(placeholders, ",")
-				expr = fmt.Sprintf("%s %s (%s)", key, inOpr, placeholdersStr)
+				expr = fmt.Sprintf("%s %s (%s)", key, inOpr, Placeholders(valVal.Len()))
 			} else {
 				expr = fmt.Sprintf("%s %s ?", key, equalOpr)
 				args = append(args, val)

--- a/placeholder.go
+++ b/placeholder.go
@@ -62,9 +62,9 @@ func (_ dollarFormat) ReplacePlaceholders(sql string) (string, error) {
 
 // Placeholders returns a string with count ? placeholders joined with commas.
 func Placeholders(count int) string {
-	placeholders := make([]string, count)
-	for i := 0; i < count; i++ {
-		placeholders[i] = "?"
+	if count < 1 {
+		return ""
 	}
-	return strings.Join(placeholders, ",")
+
+	return strings.Repeat(",?", count)[1:]
 }

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -1,6 +1,7 @@
 package squirrel
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,8 +22,22 @@ func TestDollar(t *testing.T) {
 func TestPlaceholders(t *testing.T) {
 	assert.Equal(t, Placeholders(2), "?,?")
 }
+
 func TestEscape(t *testing.T) {
 	sql := "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ??| array['?'] AND enabled = ?"
 	s, _ := Dollar.ReplacePlaceholders(sql)
 	assert.Equal(t, "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ?| array['$1'] AND enabled = $2", s)
+}
+
+func BenchmarkPlaceholdersArray(b *testing.B) {
+	var count = b.N
+	placeholders := make([]string, count)
+	for i := 0; i < count; i++ {
+		placeholders[i] = "?"
+	}
+	var _ = strings.Join(placeholders, ",")
+}
+
+func BenchmarkPlaceholdersStrings(b *testing.B) {
+	Placeholders(b.N)
 }


### PR DESCRIPTION
Benchmark result:

```
$ go test -bench .
PASS
BenchmarkPlaceholdersArray	30000000	        39.8 ns/op
BenchmarkPlaceholdersStrings	2000000000	         2.24 ns/op
ok  	squirrel	6.276s
```