### PR TITLE
Propose InsertBuilder.SetMap() function.

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -194,11 +194,11 @@ func (b InsertBuilder) Suffix(sql string, args ...interface{}) InsertBuilder {
 // SetMap set columns and values for insert builder from a map of column name and value
 // note that it will reset all previous columns and values was set if any
 func (b InsertBuilder) SetMap(clauses map[string]interface{}) InsertBuilder {
-	cols := make([]string, len(clauses))
-	vals := make([]interface{}, len(clauses))
-	idx := 0
-	for cols[idx], vals[idx] = range clauses {
-		idx++
+	cols := make([]string, 0, len(clauses))
+	vals := make([]interface{}, 0, len(clauses))
+	for col, val := range clauses {
+		cols = append(cols, col)
+		vals = append(vals, val)
 	}
 
 	b = builder.Set(b, "Columns", cols).(InsertBuilder)

--- a/insert.go
+++ b/insert.go
@@ -190,3 +190,18 @@ func (b InsertBuilder) Values(values ...interface{}) InsertBuilder {
 func (b InsertBuilder) Suffix(sql string, args ...interface{}) InsertBuilder {
 	return builder.Append(b, "Suffixes", Expr(sql, args...)).(InsertBuilder)
 }
+
+// SetMap set columns and values for insert builder from a map of column name and value
+// note that it will reset all previous columns and values was set if any
+func (b InsertBuilder) SetMap(clauses map[string]interface{}) InsertBuilder {
+	cols := make([]string, len(clauses))
+	vals := make([]interface{}, len(clauses))
+	idx := 0
+	for cols[idx], vals[idx] = range clauses {
+		idx++
+	}
+
+	b = builder.Set(b, "Columns", cols).(InsertBuilder)
+	b = builder.Set(b, "Values", [][]interface{}{vals}).(InsertBuilder)
+	return b
+}

--- a/insert_test.go
+++ b/insert_test.go
@@ -63,3 +63,16 @@ func TestInsertBuilderNoRunner(t *testing.T) {
 	_, err := b.Exec()
 	assert.Equal(t, RunnerNotSet, err)
 }
+
+func TestInsertBuilderSetMap(t *testing.T) {
+	b := Insert("table").SetMap(Eq{"field1": 1})
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "INSERT INTO table (field1) VALUES (?)"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{1}
+	assert.Equal(t, expectedArgs, args)
+}


### PR DESCRIPTION
Introduce SetMap function for InsertBuilder to set columns and values for an insert builder.
It's useful in case user want to insert or update with same dataset, depend on a special field. 

Something like:
```go
user := map[string]interface{}{"name": "Smith"}
if userID > 0 {
    qb := sq.Update("user").SetMap(user).Where(Eq{"id": userID})
} else {
    qb := sq.Insert("user").SetMap(user)
}
```