### PR TITLE
Open expression to external lib

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-type expr struct {
-	sql  string
+type Expression struct {
+	sql string
 	args []interface{}
 }
 
@@ -17,15 +17,15 @@ type expr struct {
 //
 // Ex:
 //     .Values(Expr("FROM_UNIXTIME(?)", t))
-func Expr(sql string, args ...interface{}) expr {
-	return expr{sql: sql, args: args}
+func Expr(sql string, args ...interface{}) Expression {
+	return Expression{sql: sql, args: args}
 }
 
-func (e expr) ToSql() (sql string, args []interface{}, err error) {
+func (e Expression) ToSql() (sql string, args []interface{}, err error) {
 	return e.sql, e.args, nil
 }
 
-type exprs []expr
+type exprs []Expression
 
 func (es exprs) AppendToSql(w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
 	for i, e := range es {

--- a/insert.go
+++ b/insert.go
@@ -84,7 +84,7 @@ func (d *insertData) ToSql() (sqlStr string, args []interface{}, err error) {
 	for r, row := range d.Values {
 		valueStrings := make([]string, len(row))
 		for v, val := range row {
-			e, isExpr := val.(expr)
+			e, isExpr := val.(Expression)
 			if isExpr {
 				valueStrings[v] = e.sql
 				args = append(args, e.args...)

--- a/update.go
+++ b/update.go
@@ -59,7 +59,7 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 	setSqls := make([]string, len(d.SetClauses))
 	for i, setClause := range d.SetClauses {
 		var valSql string
-		e, isExpr := setClause.value.(expr)
+		e, isExpr := setClause.value.(Expression)
 		if isExpr {
 			valSql = e.sql
 			args = append(args, e.args...)


### PR DESCRIPTION
Open the expression to external lib so they can provide their own custom expression.

for instance

```go
package extra

import (
	sq "github.com/lann/squirrel"
)

func ExprSlice(sql string, size int, args ...interface{}) sq.Expression {
	if len(args) != 1 {
		return sq.Expr(sql, args)
	}

	b := make([]interface{}, size)

	switch t := args[0].(type) {
	case []string:
	for i := range t {
		b[i] = t[i]
	}
	case []int:
	for i := range t {
		b[i] = t[i]
	}
	}

	return sq.Expr(sql, b)
}

```